### PR TITLE
revert: dependency bump to resolve type errors on master branch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@ory/integration-react",
       "version": "0.0.1",
       "dependencies": {
-        "@ory/integrations": "0.2.5",
+        "@ory/integrations": "^0.2.2",
         "@ory/kratos-client": "0.8.0-alpha.2",
         "@ory/themes": "~0.0.101",
         "classnames": "^2.3.1",
@@ -1254,24 +1254,24 @@
       }
     },
     "node_modules/@ory/integrations": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/@ory/integrations/-/integrations-0.2.5.tgz",
-      "integrity": "sha512-fX++VtRJZEA4FUBfdEl574KTtjm6lsbqqNtCxrHMX+paj7M4i01pjKU1TK69+Upe9aqdYJjCQf3qidwIPsDTNg==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@ory/integrations/-/integrations-0.2.2.tgz",
+      "integrity": "sha512-5z0Pry/jUyH03gk5rrb2eIMPD5hTwijQO59tVfb3yyGeGxPH7fCGPx3rQofyBpmzMajsVKRAHoaK6WsJr3sJrg==",
       "dependencies": {
-        "@ory/client": ">=0.0.1-alpha.49",
-        "@types/tldjs": "^2.3.1",
+        "@ory/client": ">=0.0.1-alpha.21",
+        "@ory/kratos-client": ">=0.8.0-alpha.2",
         "cookie": "^0.4.1",
         "istextorbinary": "^6.0.0",
-        "next": ">=12.0.10",
+        "next": ">=11.0.0",
         "ory-prettier-styles": "^1.1.2",
         "prettier": "^2.3.2",
         "request": "^2.88.2",
-        "set-cookie-parser": "^2.4.8",
-        "tldjs": "^2.3.1"
+        "set-cookie-parser": "^2.4.8"
       },
       "peerDependencies": {
-        "@ory/client": ">=0.0.1-alpha.49",
-        "next": ">=12.0.10"
+        "@ory/client": ">=0.0.1-alpha.21",
+        "@ory/kratos-client": ">=0.8.0-alpha.2",
+        "next": ">=11.0.0"
       }
     },
     "node_modules/@ory/integrations/node_modules/@next/env": {
@@ -1667,11 +1667,6 @@
         "@types/react": "*",
         "csstype": "^3.0.2"
       }
-    },
-    "node_modules/@types/tldjs": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@types/tldjs/-/tldjs-2.3.1.tgz",
-      "integrity": "sha512-BQR04zLE0ve2eNrqxXw/Qp/f6LxvNrj/4A8ZgdQi3SzbBqxFhleI7N4DS/mSjDnODrUaEGgoWg4grAZR1kVj8w=="
     },
     "node_modules/@types/tough-cookie": {
       "version": "4.0.1",
@@ -9465,23 +9460,6 @@
         "node": ">=0.6.0"
       }
     },
-    "node_modules/tldjs": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/tldjs/-/tldjs-2.3.1.tgz",
-      "integrity": "sha512-W/YVH/QczLUxVjnQhFC61Iq232NWu3TqDdO0S/MtXVz4xybejBov4ud+CIwN9aYqjOecEqIy0PscGkwpG9ZyTw==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "punycode": "^1.4.1"
-      },
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/tldjs/node_modules/punycode": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
-    },
     "node_modules/tmp": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
@@ -10856,20 +10834,19 @@
       }
     },
     "@ory/integrations": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/@ory/integrations/-/integrations-0.2.5.tgz",
-      "integrity": "sha512-fX++VtRJZEA4FUBfdEl574KTtjm6lsbqqNtCxrHMX+paj7M4i01pjKU1TK69+Upe9aqdYJjCQf3qidwIPsDTNg==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@ory/integrations/-/integrations-0.2.2.tgz",
+      "integrity": "sha512-5z0Pry/jUyH03gk5rrb2eIMPD5hTwijQO59tVfb3yyGeGxPH7fCGPx3rQofyBpmzMajsVKRAHoaK6WsJr3sJrg==",
       "requires": {
-        "@ory/client": ">=0.0.1-alpha.49",
-        "@types/tldjs": "^2.3.1",
+        "@ory/client": ">=0.0.1-alpha.21",
+        "@ory/kratos-client": ">=0.8.0-alpha.2",
         "cookie": "^0.4.1",
         "istextorbinary": "^6.0.0",
-        "next": ">=12.0.10",
+        "next": ">=11.0.0",
         "ory-prettier-styles": "^1.1.2",
         "prettier": "^2.3.2",
         "request": "^2.88.2",
-        "set-cookie-parser": "^2.4.8",
-        "tldjs": "^2.3.1"
+        "set-cookie-parser": "^2.4.8"
       },
       "dependencies": {
         "@next/env": {
@@ -11118,11 +11095,6 @@
         "@types/react": "*",
         "csstype": "^3.0.2"
       }
-    },
-    "@types/tldjs": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@types/tldjs/-/tldjs-2.3.1.tgz",
-      "integrity": "sha512-BQR04zLE0ve2eNrqxXw/Qp/f6LxvNrj/4A8ZgdQi3SzbBqxFhleI7N4DS/mSjDnODrUaEGgoWg4grAZR1kVj8w=="
     },
     "@types/tough-cookie": {
       "version": "4.0.1",
@@ -16856,21 +16828,6 @@
       "integrity": "sha512-9phl76Cqm6FhSX9Xe1ZUAMLtm1BLkKj2Qd5ApyWkXzsMRaA7dgr81kf4wJmQf/hAvg8EEyJxDo3du/0KlhPiKQ==",
       "requires": {
         "setimmediate": "^1.0.4"
-      }
-    },
-    "tldjs": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/tldjs/-/tldjs-2.3.1.tgz",
-      "integrity": "sha512-W/YVH/QczLUxVjnQhFC61Iq232NWu3TqDdO0S/MtXVz4xybejBov4ud+CIwN9aYqjOecEqIy0PscGkwpG9ZyTw==",
-      "requires": {
-        "punycode": "^1.4.1"
-      },
-      "dependencies": {
-        "punycode": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
-        }
       }
     },
     "tmp": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "module": "dist/index.mjs",
   "typings": "dist/index.d.ts",
   "dependencies": {
-    "@ory/integrations": "0.2.5",
+    "@ory/integrations": "^0.2.2",
     "@ory/kratos-client": "0.8.0-alpha.2",
     "@ory/themes": "~0.0.101",
     "classnames": "^2.3.1",


### PR DESCRIPTION
The dependency bump in the [most recent push](https://github.com/ory/kratos-selfservice-ui-react-nextjs/commit/aaf4cd72152d13de70d76ca3381967c79b219f0d) to the master branch has caused builds to fail on the [following type errors](https://github.com/ory/kratos-selfservice-ui-react-nextjs/runs/5768692229?check_suite_focus=true). This PR proposes a revert of the dependency bump.