### PR TITLE
Proposal: Flows refactor

### DIFF
--- a/pages/settings.tsx
+++ b/pages/settings.tsx
@@ -10,7 +10,14 @@ import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { ReactNode, useEffect, useState } from 'react'
 
-import { Flow, Methods, Messages, ActionCard, CenterLink } from '../pkg'
+import {
+  Flow,
+  Methods,
+  Messages,
+  ActionCard,
+  CenterLink,
+  OryGetOrInitializeFlow
+} from '../pkg'
 import { handleFlowError } from '../pkg/errors'
 import ory from '../pkg/sdk'
 
@@ -44,7 +51,6 @@ const Settings: NextPage = () => {
 
   // Get ?flow=... from the URL
   const router = useRouter()
-  const { flow: flowId, return_to: returnTo } = router.query
 
   useEffect(() => {
     // If the router is not ready yet, or we already have a flow, do nothing.
@@ -52,27 +58,12 @@ const Settings: NextPage = () => {
       return
     }
 
-    // If ?flow=.. was in the URL, we fetch it
-    if (flowId) {
-      ory
-        .getSelfServiceSettingsFlow(String(flowId))
-        .then(({ data }) => {
-          setFlow(data)
-        })
-        .catch(handleFlowError(router, 'settings', setFlow))
-      return
-    }
-
-    // Otherwise we initialize it
-    ory
-      .initializeSelfServiceSettingsFlowForBrowsers(
-        returnTo ? String(returnTo) : undefined
-      )
-      .then(({ data }) => {
-        setFlow(data)
-      })
-      .catch(handleFlowError(router, 'settings', setFlow))
-  }, [flowId, router, router.isReady, returnTo, flow])
+    OryGetOrInitializeFlow<SelfServiceSettingsFlow>(
+      'settings',
+      router,
+      setFlow
+    ).then(setFlow)
+  }, [router, router.isReady, router.query, flow])
 
   const onSubmit = (values: SubmitSelfServiceSettingsFlowBody) =>
     router

--- a/pkg/hooks.tsx
+++ b/pkg/hooks.tsx
@@ -1,8 +1,16 @@
 import { AxiosError } from 'axios'
-import { useRouter } from 'next/router'
-import { useState, useEffect, DependencyList } from 'react'
+import { NextRouter, useRouter } from 'next/router'
+import {
+  useState,
+  useEffect,
+  DependencyList,
+  Dispatch,
+  SetStateAction
+} from 'react'
 
+import { handleGetFlowError } from './errors'
 import ory from './sdk'
+import { OrySelfServiceFlow, OryFlowType, OryPageQuery } from './types'
 
 // Returns a function which will log the user out
 export function createLogoutHandler(deps?: DependencyList) {
@@ -35,4 +43,95 @@ export function createLogoutHandler(deps?: DependencyList) {
         .then(() => router.reload())
     }
   }
+}
+
+/**
+ * Get self-service flow
+ */
+export const OryGetSelfServiceFlow = (
+  flowType: OryFlowType,
+  query: OryPageQuery
+) => {
+  switch (flowType) {
+    case 'login':
+      return ory.getSelfServiceLoginFlow(`${query.flow || ''}`)
+      break
+    case 'recovery':
+      return ory.getSelfServiceRecoveryFlow(`${query.flow || ''}`)
+      break
+    case 'registration':
+      return ory.getSelfServiceRegistrationFlow(`${query.flow || ''}`)
+      break
+    case 'settings':
+      return ory.getSelfServiceSettingsFlow(`${query.flow || ''}`)
+      break
+    case 'verification':
+      return ory.getSelfServiceVerificationFlow(`${query.flow || ''}`)
+      break
+    default:
+      return Promise.reject(`Unsupported flow type ${flowType}`)
+      break
+  }
+}
+
+/**
+ * Get self-service flow
+ */
+export const OryInitializeSelfServiceFlow = (
+  flowType: OryFlowType,
+  query: OryPageQuery
+) => {
+  switch (flowType) {
+    case 'login':
+      return ory.initializeSelfServiceLoginFlowForBrowsers(
+        Boolean(query.refresh),
+        query.aal,
+        query.return_to
+      )
+      break
+    case 'recovery':
+      return ory.initializeSelfServiceRecoveryFlowForBrowsers(query.return_to)
+      break
+    case 'registration':
+      return ory.initializeSelfServiceRegistrationFlowForBrowsers(
+        query.return_to
+      )
+      break
+    case 'settings':
+      return ory.initializeSelfServiceSettingsFlowForBrowsers(query.return_to)
+      break
+    case 'verification':
+      return ory.initializeSelfServiceVerificationFlowForBrowsers(
+        query.return_to
+      )
+      break
+    default:
+      return Promise.reject(`Unsupported flow type ${flowType}`)
+      break
+  }
+}
+
+/**
+ * Initialize a flow
+ */
+export const OryGetOrInitializeFlow = <S extends OrySelfServiceFlow>(
+  flowType: OryFlowType,
+  router: NextRouter,
+  resetFlow: Dispatch<SetStateAction<S | undefined>>
+): Promise<S> => {
+  const query = router.query as OryPageQuery
+
+  return (
+    query.flow
+      ? OryGetSelfServiceFlow(flowType, query)
+      : OryInitializeSelfServiceFlow(flowType, query)
+  )
+    .catch(handleGetFlowError(router, flowType, resetFlow))
+    .then((data) => {
+      if (!data) {
+        return Promise.reject()
+      }
+
+      return data.data as S
+    })
 }

--- a/pkg/types.ts
+++ b/pkg/types.ts
@@ -1,0 +1,43 @@
+import {
+  SelfServiceLoginFlow,
+  SelfServiceRecoveryFlow,
+  SelfServiceRegistrationFlow,
+  SelfServiceSettingsFlow,
+  SelfServiceVerificationFlow
+} from '@ory/client'
+
+/**
+ * Ory flow response
+ */
+export type OrySelfServiceFlow =
+  | SelfServiceLoginFlow
+  | SelfServiceRecoveryFlow
+  | SelfServiceRegistrationFlow
+  | SelfServiceSettingsFlow
+  | SelfServiceVerificationFlow
+
+/**
+ * Ory flow type
+ */
+export type OryFlowType =
+  | 'login'
+  | 'registration'
+  | 'settings'
+  | 'recovery'
+  | 'verification'
+
+/**
+ * Ory page query
+ */
+export type OryPageQuery = {
+  // URL to return to after logging in
+  return_to?: string
+  // Existing flow ID
+  flow?: string
+  // Session refresh request
+  // Example use: when we want to update the password
+  refresh?: string
+  // AAL = Authorization Assurance Level (two-factor auth)
+  // This implies that we want to upgrade the AAL
+  aal?: string
+}


### PR DESCRIPTION
# Description

While following this NextJS example and implementing [my own frontend](https://github.com/lstellway/ory-selfservice-ui-nextjs), I saw the same pattern was used for all of the user flows _(get or initialize the flow based on the router query)_. 

I thought it could be nice to abstract it outside of the view into a helper - let me know what you think!
