### PR TITLE
feat: ui should respect settings return-to

### DIFF
--- a/cypress/integration/pages.spec.js
+++ b/cypress/integration/pages.spec.js
@@ -20,7 +20,9 @@ context("Ory Kratos pages", () => {
     cy.get('[name="traits.email"]').type(email)
     cy.get('[name="password"]').type(password)
     cy.get('[name="method"]').click()
-    cy.location("pathname").should("eq", "/")
+    cy.location("pathname").should("eq", "/verification")
+
+    cy.visit("/")
     cy.get('[data-testid="logout"]').should(
       "have.attr",
       "aria-disabled",

--- a/pages/api/.ory/[...paths].ts
+++ b/pages/api/.ory/[...paths].ts
@@ -10,4 +10,8 @@ export default createApiHandler({
   // Because vercel.app is a public suffix and setting cookies for
   // vercel.app is not possible.
   dontUseTldForCookieDomain: true,
+  // we require this since we are proxying the Ory requests through nextjs
+  // Ory needs to know about our host to generate the correct urls for redirecting back between flows
+  // For example between Login MFA and Settings
+  forwardAdditionalHeaders: ["x-forwarded-host"],
 })

--- a/pages/recovery.tsx
+++ b/pages/recovery.tsx
@@ -37,7 +37,9 @@ const Recovery: NextPage = () => {
 
     // Otherwise we initialize it
     ory
-      .createBrowserRecoveryFlow()
+      .createBrowserRecoveryFlow({
+        returnTo: String(returnTo || ""),
+      })
       .then(({ data }) => {
         setFlow(data)
       })

--- a/pages/settings.tsx
+++ b/pages/settings.tsx
@@ -102,7 +102,6 @@ const Settings: NextPage = () => {
               window.location.href = data.return_to
               return
             }
-
           })
           .catch(handleFlowError(router, "settings", setFlow))
           .catch(async (err: AxiosError) => {

--- a/pages/settings.tsx
+++ b/pages/settings.tsx
@@ -63,7 +63,7 @@ const Settings: NextPage = () => {
     // Otherwise we initialize it
     ory
       .createBrowserSettingsFlow({
-        returnTo: returnTo ? String(returnTo) : undefined,
+        returnTo: String(returnTo || ""),
       })
       .then(({ data }) => {
         setFlow(data)
@@ -97,6 +97,12 @@ const Settings: NextPage = () => {
                 }
               }
             }
+
+            if (data.return_to) {
+              window.location.href = data.return_to
+              return
+            }
+
           })
           .catch(handleFlowError(router, "settings", setFlow))
           .catch(async (err: AxiosError) => {

--- a/pkg/errors.tsx
+++ b/pkg/errors.tsx
@@ -10,7 +10,6 @@ export function handleGetFlowError<S>(
   resetFlow: Dispatch<SetStateAction<S | undefined>>,
 ) {
   return async (err: AxiosError) => {
-    console.log(err.response?.data.error)
     switch (err.response?.data.error?.id) {
       case "session_inactive":
         await router.push("/login?return_to=" + window.location.href)
@@ -21,7 +20,6 @@ export function handleGetFlowError<S>(
           if (flowType === "settings") {
             redirectTo.searchParams.set("return_to", window.location.href)
           }
-          console.log("redirecting to", redirectTo.toString())
           // 2FA is enabled and enforced, but user did not perform 2fa yet!
           window.location.href = redirectTo.toString()
           return

--- a/pkg/errors.tsx
+++ b/pkg/errors.tsx
@@ -10,13 +10,23 @@ export function handleGetFlowError<S>(
   resetFlow: Dispatch<SetStateAction<S | undefined>>,
 ) {
   return async (err: AxiosError) => {
+    console.log(err.response?.data.error)
     switch (err.response?.data.error?.id) {
       case "session_inactive":
-        await router.push("/login")
+        await router.push("/login?return_to=" + window.location.href)
         return
       case "session_aal2_required":
-        // 2FA is enabled and enforced, but user did not perform 2fa yet!
-        window.location.href = err.response?.data.redirect_browser_to
+        if (err.response?.data.redirect_browser_to) {
+          const redirectTo = new URL(err.response?.data.redirect_browser_to)
+          if (flowType === "settings") {
+            redirectTo.searchParams.set("return_to", window.location.href)
+          }
+          console.log("redirecting to", redirectTo.toString())
+          // 2FA is enabled and enforced, but user did not perform 2fa yet!
+          window.location.href = redirectTo.toString()
+          return
+        }
+        await router.push("/login?aal=aal2&return_to=" + window.location.href)
         return
       case "session_already_available":
         // User is already signed in, let's redirect them home!

--- a/pkg/errors.tsx
+++ b/pkg/errors.tsx
@@ -11,6 +11,9 @@ export function handleGetFlowError<S>(
 ) {
   return async (err: AxiosError) => {
     switch (err.response?.data.error?.id) {
+      case "session_inactive":
+        await router.push("/login")
+        return
       case "session_aal2_required":
         // 2FA is enabled and enforced, but user did not perform 2fa yet!
         window.location.href = err.response?.data.redirect_browser_to


### PR DESCRIPTION
This PR gives the settings page the ability to use the `return_to` value from the settings API payload. This is mostly business logic for e2e tests in Kratos.