### PR TITLE
feat: prevent proxy when specifying `NEXT_PUBLIC_KRATOS_PUBLIC_URL`

### DIFF
--- a/pkg/sdk/index.ts
+++ b/pkg/sdk/index.ts
@@ -1,4 +1,12 @@
 import { Configuration, FrontendApi } from "@ory/client"
 import { edgeConfig } from "@ory/integrations/next"
 
-export default new FrontendApi(new Configuration(edgeConfig))
+const localConfig = {
+  basePath: process.env.NEXT_PUBLIC_KRATOS_PUBLIC_URL,
+}
+
+export default new FrontendApi(
+  new Configuration(
+    process.env.NEXT_PUBLIC_KRATOS_PUBLIC_URL ? localConfig : edgeConfig,
+  ),
+)


### PR DESCRIPTION
This configures the Ory SDK to use the local instance of Ory when the `NEXT_PUBLIC_KRATOS_PUBLIC_URL` is specified. This is for local and CI tests of Ory Kratos, since the proxy doesn't need to be used in these cases. 

The reason for this is due to large amounts of csrf errors on localhost when the request goes through the nextjs proxy. 

I have also bound the nextjs application to `127.0.0.1` instead of the host `0.0.0.0` due to the tests proxy not able to make requests to the nextjs application when the nextjs application is bound to ipv6 `::1:4458`. 